### PR TITLE
Added config for inverse unit formatting (s/it)

### DIFF
--- a/src/progress/bar.rs
+++ b/src/progress/bar.rs
@@ -454,15 +454,16 @@ impl Bar {
     }
 
     pub(crate) fn fmt_rate(&self) -> String {
+        let rate = self.rate();
         if self.counter == 0 {
             format!("?{}/s", self.unit)
-        } else if self.rate() < 1. {
+        } else if rate < 1. {
             format!(
                 "{}/{}",
                 if self.unit_scale {
-                    format::format_time(1. / (self.rate() as f64))
+                    format::format_time(1. / (rate as f64))
                 } else {
-                    format!("{:.2}s", 1. / self.rate())
+                    format!("{:.2}s", 1. / rate)
                 },
                 self.unit
             )
@@ -470,9 +471,9 @@ impl Bar {
             format!(
                 "{}{}/s",
                 if self.unit_scale {
-                    format::format_sizeof(self.rate() as f64, self.unit_divisor as f64)
+                    format::format_sizeof(rate as f64, self.unit_divisor as f64)
                 } else {
-                    format!("{:.2}", self.rate())
+                    format!("{:.2}", rate)
                 },
                 self.unit
             )

--- a/src/styles/format.rs
+++ b/src/styles/format.rs
@@ -24,6 +24,18 @@ pub fn format_sizeof(num: f64, divisor: f64) -> String {
     format!("{:3.1}Y", value)
 }
 
+pub fn format_time(num: f64) -> String {
+    let mut value = num;
+    let units = [(60., "s"), (60., "min"), (24., "hr")];
+    for (d, i) in units {
+        if value.abs() < d - 0.005 {
+            return format!("{value:1.2}{i}");
+        }
+        value /= d;
+    }
+    format!("{value:1.2}days")
+}
+
 /// Formats a number of seconds as a clock time, \[H:\]MM:SS and SSs.
 pub fn format_interval(seconds: usize, human: bool) -> String {
     if human && seconds < 60 {
@@ -48,3 +60,4 @@ pub fn format_interval(seconds: usize, human: bool) -> String {
 //     let n = format!("{}", n).to_string();
 //     return if f.len() < n.len() { f } else { n };
 // }
+


### PR DESCRIPTION
It's a simple config, it only changes bar behaviour when `self.rate()<1` and it takes unit scale in consideration if it's also enabled.