### PR TITLE
Update PyO3 to 0.21

### DIFF
--- a/kdam/Cargo.toml
+++ b/kdam/Cargo.toml
@@ -15,7 +15,7 @@ version = "0.5.1"
 colorgrad = { version = "0.6", optional = true }
 formatx = { version = "0.2.1", optional = true }
 kdam_derive = { version = "0.1.0", path = "../kdam_derive", optional = true }
-pyo3 = { version = "0.20", optional = true }
+pyo3 = { version = "0.21", optional = true }
 rayon = { version = "1.8", optional = true }
 terminal_size = "0.3"
 unicode-segmentation = { version = "1", optional = true }

--- a/kdam/examples/miscellaneous/file_download/Cargo.toml
+++ b/kdam/examples/miscellaneous/file_download/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-reqwest = { version = "0.11", features = ["stream"] }
+reqwest = { version = "0.12", features = ["stream"] }
 futures-util = "0.3"
 tokio = { version = "1", features = ["full"] }
 kdam = { path = "../../.." }

--- a/kdam/examples/notebook/Cargo.toml
+++ b/kdam/examples/notebook/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 kdam = { path = "../..", features = ["notebook", "template"] }
-pyo3 = { version = "0.20", features = ["extension-module"] }
+pyo3 = { version = "0.21", features = ["extension-module"] }
 
 [build-dependencies]
-pyo3-build-config = "0.20"
+pyo3-build-config = "0.21"

--- a/kdam/examples/notebook/src/lib.rs
+++ b/kdam/examples/notebook/src/lib.rs
@@ -36,7 +36,7 @@ fn progress_bar_with_template() -> PyResult<()> {
 }
 
 #[pymodule]
-fn kdam_notebook(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
+fn kdam_notebook(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(set_notebook, m)?)?;
     m.add_function(wrap_pyfunction!(progress_bar, m)?)?;
     m.add_function(wrap_pyfunction!(progress_bar_with_template, m)?)?;


### PR DESCRIPTION
I've opened the PR because kdam still uses PyO3 0.20 while 0.21 was released two months ago. I did not update version numbers nor did anything besides updating the PyO3 version and fixing deprecation warnings caused by this update.