### PR TITLE
Support pyo3 version 0.22

### DIFF
--- a/kdam/Cargo.toml
+++ b/kdam/Cargo.toml
@@ -15,7 +15,7 @@ version = "0.5.2"
 colorgrad = { version = "0.6", optional = true }
 formatx = { version = "0.2.2", optional = true }
 kdam_derive = { version = "0.1.0", path = "../kdam_derive", optional = true }
-pyo3 = { version = "0.21", optional = true }
+pyo3 = { version = "0.22.5", optional = true }
 rayon = { version = "1.10", optional = true }
 terminal_size = "0.3"
 unicode-segmentation = { version = "1", optional = true }

--- a/kdam/examples/notebook/Cargo.toml
+++ b/kdam/examples/notebook/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 kdam = { path = "../..", features = ["notebook", "template"] }
-pyo3 = { version = "0.21", features = ["extension-module"] }
+pyo3 = { version = "0.22.5", features = ["extension-module"] }
 
 [build-dependencies]
-pyo3-build-config = "0.21"
+pyo3-build-config = "0.22.5"

--- a/kdam/src/std/bar.rs
+++ b/kdam/src/std/bar.rs
@@ -27,6 +27,7 @@ use crate::spinner::Spinner;
 #[cfg(feature = "template")]
 use formatx::Template;
 
+
 /// Core implemention of console progress bar.
 ///
 /// # Example
@@ -72,7 +73,7 @@ pub struct Bar {
     // Non Builder Fields
     pub bar_length: u16,
     #[cfg(feature = "notebook")]
-    container: Option<Py<PyAny>>,
+    container: Option<notebook::PyContainer>,
     pub counter: usize,
     current_ncols: u16,
     elapsed_time: f32,

--- a/kdam/src/std/notebook.rs
+++ b/kdam/src/std/notebook.rs
@@ -1,6 +1,32 @@
 use std::sync::atomic::{AtomicBool, Ordering};
+use pyo3::{Bound, Py, PyAny, Python};
 
 static RUNNING: AtomicBool = AtomicBool::new(false);
+
+#[derive(Debug)]
+pub(crate) struct PyContainer(Py<PyAny>);
+
+impl Clone for PyContainer {
+    fn clone(&self) -> Self {
+        Python::with_gil(|py| {
+            PyContainer(self.0.clone_ref(py))
+        })
+    }
+}
+
+impl PyContainer {
+    #[inline]
+    pub fn bind<'py>(&self, py: Python<'py>) -> &Bound<'py, PyAny> {
+        self.0.bind(py)
+    }
+}
+
+impl<'py> From<Bound<'py, PyAny>> for PyContainer {
+    fn from(value: Bound<'py, PyAny>) -> Self {
+        Self(value.into())
+    }
+}
+
 
 /// Set whether `kdam` is running inside a jupyter notebook or not.
 pub fn set_notebook(running: bool) {


### PR DESCRIPTION
- Changes the version of the pyo3 dependency to 0.22.5
- Adds a wrapper around `Py<PyAny>` with a `Clone` implementation that acquires the GIL instead of panicking 

Note that releasing this requires a bump to `0.6` as a project cannot have multiple versions of pyo3 in its dependencies (main reason I am making this PR in the first place).