### PR TITLE
Support pyo3 up to 0.25

### DIFF
--- a/kdam/Cargo.toml
+++ b/kdam/Cargo.toml
@@ -15,7 +15,7 @@ version = "0.6.2"
 colorgrad = { version = "0.7", optional = true }
 formatx = { version = "0.2.2", optional = true }
 kdam_derive = { version = "0.1.0", path = "../kdam_derive", optional = true }
-pyo3 = { version = "0.23", optional = true }
+pyo3 = { version = ">=0.23,<0.26", optional = true }
 rayon = { version = "1.10", optional = true }
 terminal_size = "0.4"
 unicode-segmentation = { version = "1", optional = true }

--- a/kdam/examples/notebook/Cargo.toml
+++ b/kdam/examples/notebook/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 kdam = { path = "../..", features = ["notebook", "template"] }
-pyo3 = { version = "0.23", features = ["extension-module"] }
+pyo3 = { version = ">=0.23,<0.26", features = ["extension-module"] }
 
 [build-dependencies]
-pyo3-build-config = "0.23"
+pyo3-build-config = ">=0.23,<0.26"


### PR DESCRIPTION
Hi, this PR adds support for pyo3 0.25.

Since there is no code change required it actually supports pyo3 0.23 up to 0.25, because why not.